### PR TITLE
fix: Add default to schema

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -7,7 +7,8 @@
     "dsn": {
       "type": "string",
       "title": "DSN",
-      "description": "Sentry DSN like https://aaaacccc99994444bbbb55550000dddd@a1234567.ingest.sentry.io/9876543"
+      "description": "Sentry DSN like https://aaaacccc99994444bbbb55550000dddd@a1234567.ingest.sentry.io/9876543",
+      "default": "https://aaaacccc99994444bbbb55550000dddd@a1234567.ingest.sentry.io/9876543"
     }
   },
   "additionalProperties": false


### PR DESCRIPTION
Without default value, applying overrides.json causes error
```
/home/leechanghwan/miniconda3/envs/jupyterlab-ext/share/jupyter/lab/settings/overrides.json {'@jupyterlab/translation-extension:plugin': {'locale': 'ko_KR'}, '@jupyterlab/notebook-extension:tracker': {'kernelShutdown': True}, '@jupyterlab/docmanager-extension:plugin': {'autosaveInterval': 10}, 'jupyterlab-sentry:plugin': {'dsn': '<xxx>'}}
[E 2022-04-13 00:02:34.063 ServerApp] Uncaught exception GET /lab/api/settings?1649775752055 (127.0.0.1)
    HTTPServerRequest(protocol='http', host='localhost:8888', method='GET', uri='/lab/api/settings?1649775752055', version='HTTP/1.1', remote_ip='127.0.0.1')
    Traceback (most recent call last):
      File "/home/leechanghwan/miniconda3/envs/jupyterlab-ext/lib/python3.10/site-packages/tornado/web.py", line 1702, in _execute
        result = method(*self.path_args, **self.path_kwargs)
      File "/home/leechanghwan/miniconda3/envs/jupyterlab-ext/lib/python3.10/site-packages/tornado/web.py", line 3173, in wrapper
        return method(self, *args, **kwargs)
      File "/home/leechanghwan/miniconda3/envs/jupyterlab-ext/lib/python3.10/site-packages/jupyterlab_server/settings_handler.py", line 41, in get
        result, warnings = get_settings(
      File "/home/leechanghwan/miniconda3/envs/jupyterlab-ext/lib/python3.10/site-packages/jupyterlab_server/settings_utils.py", line 376, in get_settings
        settings_list, warnings = _list_settings(
      File "/home/leechanghwan/miniconda3/envs/jupyterlab-ext/lib/python3.10/site-packages/jupyterlab_server/settings_utils.py", line 202, in _list_settings
        schema, version = _get_schema(schemas_dir, schema_name, overrides, labextensions_path=labextensions_path)
      File "/home/leechanghwan/miniconda3/envs/jupyterlab-ext/lib/python3.10/site-packages/jupyterlab_server/settings_utils.py", line 54, in _get_schema
        schema = _override(schema_name, schema, overrides)
      File "/home/leechanghwan/miniconda3/envs/jupyterlab-ext/lib/python3.10/site-packages/jupyterlab_server/settings_utils.py", line 228, in _override
        new_defaults = schema['properties'][key]['default']
    KeyError: 'default'
[W 2022-04-13 00:02:34.064 LabApp] Unhandled error
[E 2022-04-13 00:02:34.064 LabApp] {
      "Host": "localhost:8888",
      "Accept": "*/*",
      "Referer": "http://localhost:8888/lab",
      "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.75 Safari/537.36"
    }
[E 2022-04-13 00:02:34.064 LabApp] 500 GET /lab/api/settings?1649775752055 (127.0.0.1) 28.23ms referer=http://localhost:8888/lab
```