### PR TITLE
Automated Changelog Entry for 0.2.1 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.2.1
+
+([Full Changelog](https://github.com/team-monolith-product/jupyterlab-sentry/compare/v0.2.0...5a0593d34d657e47226b4e73202b9b40ec4d04a6))
+
+### Merged PRs
+
+- fix: Add default to schema [#2](https://github.com/team-monolith-product/jupyterlab-sentry/pull/2) ([@a3626a](https://github.com/a3626a))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-sentry/graphs/contributors?from=2022-04-12&to=2022-04-12&type=c))
+
+[@a3626a](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-sentry+involves%3Aa3626a+updated%3A2022-04-12..2022-04-12&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.0
 
 No merged PRs
-
-<!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.2.1 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | team-monolith-product/jupyterlab-sentry  |
| Branch  | main  |
| Version Spec | 0.2.1 |
| Since Last Stable | true |