### PR TITLE
Automated Changelog Entry for 1.0.0 on 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 1.0.0
+
+([Full Changelog](https://github.com/team-monolith-product/jupyterlab-sentry/compare/v0.2.1...0c2a30edf86436add78f4d12cd60cc2db6ba5d8e))
+
+### Merged PRs
+
+- feat: update to jupyter lab 4 [#4](https://github.com/team-monolith-product/jupyterlab-sentry/pull/4) ([@a3626a](https://github.com/a3626a))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-sentry/graphs/contributors?from=2022-04-12&to=2022-10-08&type=c))
+
+[@a3626a](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-sentry+involves%3Aa3626a+updated%3A2022-04-12..2022-10-08&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.2.1
 
 ([Full Changelog](https://github.com/team-monolith-product/jupyterlab-sentry/compare/v0.2.0...5a0593d34d657e47226b4e73202b9b40ec4d04a6))
@@ -15,8 +31,6 @@
 ([GitHub contributors page for this release](https://github.com/team-monolith-product/jupyterlab-sentry/graphs/contributors?from=2022-04-12&to=2022-04-12&type=c))
 
 [@a3626a](https://github.com/search?q=repo%3Ateam-monolith-product%2Fjupyterlab-sentry+involves%3Aa3626a+updated%3A2022-04-12..2022-04-12&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.2.0
 


### PR DESCRIPTION
Automated Changelog Entry for 1.0.0 on 1.0

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Draft Release | https://github.com/team-monolith-product/jupyterlab-sentry/releases/tag/untagged-7e900521662219169351  |
| Since | v0.2.1 |